### PR TITLE
chore(render): ajustar healthCheckPath y uso de PORT; alinear config …

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,7 @@ http {
     keepalive_timeout  65;
 
     server {
-        listen 80;
+        listen ${PORT};
         server_name  localhost;
         root /var/www/html/public;
 

--- a/render.yaml
+++ b/render.yaml
@@ -7,18 +7,9 @@ services:
     plan: free
     autoDeploy: true
     dockerfilePath: ./Dockerfile
-    healthCheckPath: /up
-    buildCommand: |
-      composer install --no-dev --optimize-autoloader
-      npm install
-      npm run build
-    startCommand: |
-      php artisan migrate --force
-      php artisan config:cache
-      php artisan route:cache
-      php artisan view:cache
-      php artisan storage:link
-      apache2-foreground
+    healthCheckPath: /
+    # Con env: docker y dockerfilePath, Render usa el Dockerfile.
+    # No se requieren buildCommand/startCommand aquí; el entrypoint del contenedor maneja build/run.
     envVars:
       - key: APP_NAME
         value: Sistema de Asignación de Salones


### PR DESCRIPTION
…con Dockerfile entrypoint\n\n- nginx: escuchar  para compatibilidad con Render\n- render.yaml: eliminar build/startCommand en env docker; healthCheckPath=/\n- despliegue: usar docker-entrypoint (nginx+php-fpm+migraciones y caches)